### PR TITLE
Latest fixes

### DIFF
--- a/components/articles/ArticleEditor.tsx
+++ b/components/articles/ArticleEditor.tsx
@@ -9,6 +9,8 @@ import { FeaturedImageGenerator } from "@/components/featured/FeaturedImageGener
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { useRouter } from "next/navigation";
 import { useArticleState } from "@/hooks/useArticleState";
+import { TranslatePanel } from "./sidebar/panels/TranslatePanel";
+import { LocationPanel } from "./sidebar/panels/LocationPanel";
 
 export function ArticleEditor() {
   const router = useRouter();
@@ -55,6 +57,14 @@ export function ArticleEditor() {
       return <FeaturedImageGenerator seoKeyword={content.seoKeyword} />;
     }
     
+    if (activeSection === "translate") {
+      return <TranslatePanel />;
+    }
+    
+    if (activeSection === "location") {
+      return <LocationPanel />;
+    }
+    
     return (
       <EditorContent
         content={content}
@@ -75,11 +85,11 @@ export function ArticleEditor() {
         <div className="flex">
           <div className={cn(
             "flex-1",
-            activeSection === "featured" && "ml-0"
+            !["featured", "translate", "location"].includes(activeSection) && "ml-0"
           )}>
             {renderSection()}
           </div>
-          {activeSection !== "featured" && (
+          {!["featured", "translate", "location"].includes(activeSection) && (
             <EditorSidebar
               activeSection={activeSection}
               status={status}

--- a/components/articles/content/EditorContent.tsx
+++ b/components/articles/content/EditorContent.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useRef, useCallback } from "react";
-import { Input, Textarea } from "@/components/ui/textarea";
+import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 import { BlockList } from "./blocks/BlockList";
 import { AddBlockButton } from "./blocks/AddBlockButton";
@@ -14,7 +14,6 @@ import type { Block } from "@/lib/types/article";
 interface EditorContentProps {
   content: {
     headline: string;
-    blocks: Block[];
     blocks: Block[];
   };
   onChange: (field: "headline" | "blocks", value: any) => void;

--- a/components/articles/content/toolbar/FloatingToolbar.tsx
+++ b/components/articles/content/toolbar/FloatingToolbar.tsx
@@ -36,7 +36,7 @@ export function FloatingToolbar({ onFormat }: FloatingToolbarProps) {
   return (
     <div 
       className={cn(
-        "fixed left-[calc(50%-500px)] top-[120px]",
+        "fixed left-[calc(20%-200px)] top-[120px]",
         "flex flex-col items-center gap-1 p-2",
         "bg-white/90 backdrop-blur-sm rounded-lg shadow-lg",
         "border border-gray-200",

--- a/components/articles/sidebar/EditorSidebar.tsx
+++ b/components/articles/sidebar/EditorSidebar.tsx
@@ -16,12 +16,16 @@ interface EditorSidebarProps {
   status: ArticleStatus;
   authors: string[];
   isSponsored: boolean;
+  isScheduled: boolean;
+  scheduledDate: Date | null;
   content: ArticleContent;
   timeTracking: TimeTrackingData;
   onAuthorsChange: (authors: string[]) => void;
   onSponsoredChange: (sponsored: boolean) => void;
   onUnpublish: () => void;
   onDelete: () => void;
+  onScheduleToggle: () => void;
+  onScheduleChange: (date: Date | null) => void;
 }
 
 export function EditorSidebar({
@@ -29,10 +33,14 @@ export function EditorSidebar({
   status,
   authors,
   isSponsored,
+  isScheduled,
+  scheduledDate,
   content,
   timeTracking,
   onAuthorsChange,
   onSponsoredChange,
+  onScheduleToggle,
+  onScheduleChange,
   onUnpublish,
   onDelete
 }: EditorSidebarProps) {
@@ -50,6 +58,10 @@ export function EditorSidebar({
             onSponsoredChange={onSponsoredChange}
             onUnpublish={onUnpublish}
             onDelete={onDelete}
+            isScheduled={isScheduled}
+            scheduledDate={scheduledDate}
+            onScheduleToggle={onScheduleToggle}
+            onScheduleChange={onScheduleChange}
           />
         );
       case "section":
@@ -63,7 +75,7 @@ export function EditorSidebar({
       case "distribute":
         return <DistributePanel />;
       case "editor":
-        return <EditorPanel content={content} onAnalyze={() => {}} />;
+        return <EditorPanel content={content} onAnalyze={() => { }} />;
       default:
         return null;
     }
@@ -71,10 +83,10 @@ export function EditorSidebar({
   return (
     <div className={cn(
       "border-l border-[#F2F4F7] bg-white",
-      activeSection === "location" ? "w-[800px] p-0" : 
-      activeSection === "translate" ? "w-[800px] p-0" :
-      activeSection === "editor" ? "w-[500px] p-6 space-y-6" :
-      "w-[383px] p-6 space-y-6"
+      activeSection === "location" ? "w-[800px] p-0" :
+        activeSection === "translate" ? "w-[800px] p-0" :
+          activeSection === "editor" ? "w-[500px] p-6 space-y-6" :
+            "w-[383px] p-6 space-y-6"
     )}>
       {renderPanel()}
     </div>

--- a/components/articles/sidebar/EditorSidebar.tsx
+++ b/components/articles/sidebar/EditorSidebar.tsx
@@ -68,10 +68,6 @@ export function EditorSidebar({
         return <SectionPanel />;
       case "seo":
         return <SeoPanel />;
-      case "location":
-        return <LocationPanel />;
-      case "translate":
-        return <TranslatePanel />;
       case "distribute":
         return <DistributePanel />;
       case "editor":

--- a/components/articles/sidebar/ScheduleSelector.tsx
+++ b/components/articles/sidebar/ScheduleSelector.tsx
@@ -57,14 +57,14 @@ export function ScheduleSelector({
         <Button
           variant="outline"
           className={cn(!isScheduled && "bg-gray-100")}
-          onClick={() => !isScheduled && onToggle()}
+          onClick={() => onToggle()}
         >
           Now
         </Button>
         <Button
           variant="outline"
           className={cn(isScheduled && "bg-gray-100")}
-          onClick={() => !isScheduled && onToggle()}
+          onClick={() => onToggle()}
         >
           Schedule
         </Button>

--- a/components/articles/sidebar/panels/location/LocationMap.tsx
+++ b/components/articles/sidebar/panels/location/LocationMap.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import dynamic from "next/dynamic";
 import "leaflet/dist/leaflet.css";
 import type { Location } from "@/lib/types/location";
@@ -14,92 +14,112 @@ interface LocationMapProps {
   onMapClick: (lat: number, lng: number) => void;
 }
 
-function LeafletMap({
-  locations,
-  selectedLocation,
-  onMarkerClick,
-  onMarkerDragStart,
-  onMarkerDragEnd,
-  onMapClick,
-}: LocationMapProps) {
+const LeafletMap = ({ 
+  locations, 
+  selectedLocation, 
+  onMarkerClick, 
+  onMarkerDragStart, 
+  onMarkerDragEnd, 
+  onMapClick 
+}: LocationMapProps) => {
   const mapRef = useRef<L.Map | null>(null);
   const markersRef = useRef<Map<string, L.Marker>>(new Map());
+  const [L, setL] = useState<typeof import('leaflet') | null>(null);
+
+  // Load Leaflet dynamically
+  useEffect(() => {
+    const loadLeaflet = async () => {
+      const leafletModule = await import("leaflet");
+      setL(leafletModule);
+    };
+    loadLeaflet();
+  }, []);
 
   // Initialize map
   useEffect(() => {
-    const initMap = async () => {
-      if (mapRef.current) return;
+    if (!L) return;
 
-      const L = (await import("leaflet")).default;
+    // Fix Leaflet icon path issue
+    delete (L.Icon.Default.prototype as any)._getIconUrl;
+    L.Icon.Default.mergeOptions({
+      iconRetinaUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon-2x.png',
+      iconUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon.png',
+      shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-shadow.png',
+    });
 
-      // Fix Leaflet icon path issue
-      delete (L.Icon.Default.prototype as any)._getIconUrl;
-      L.Icon.Default.mergeOptions({
-        iconRetinaUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon-2x.png',
-        iconUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon.png',
-        shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-shadow.png',
-      });
+    // Cleanup existing map if it exists
+    if (mapRef.current) {
+      mapRef.current.remove();
+      mapRef.current = null;
+    }
 
-      const defaultCenter = { lat: 33.8938, lng: 35.5018 }; // Beirut
+    const mapContainer = document.getElementById('map');
+    if (!mapContainer) return;
 
-      mapRef.current = L.map("map", {
-        center: [defaultCenter.lat, defaultCenter.lng],
-        zoom: 13,
-        zoomControl: true,
-      });
+    const defaultCenter = { lat: 33.8938, lng: 35.5018 }; // Beirut
+    
+    mapRef.current = L.map(mapContainer, {
+      center: [defaultCenter.lat, defaultCenter.lng],
+      zoom: 13,
+      zoomControl: true,
+    });
 
-      // Add OpenStreetMap tiles
-      L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
-        attribution:
-          '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-        maxZoom: 19,
-      }).addTo(mapRef.current);
+    // Add OpenStreetMap tiles
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+      maxZoom: 19,
+    }).addTo(mapRef.current);
 
-      // Add click listener
-      mapRef.current.on("click", (e) => {
-        onMapClick(e.latlng.lat, e.latlng.lng);
-      });
-    };
+    // Add click listener
+    mapRef.current.on('click', (e) => {
+      onMapClick(e.latlng.lat, e.latlng.lng);
+    });
 
-    initMap();
-
+    // Cleanup
     return () => {
       if (mapRef.current) {
         mapRef.current.remove();
         mapRef.current = null;
       }
     };
-  }, [onMapClick]);
+  }, [L, onMapClick]);
 
   // Update markers
   useEffect(() => {
-    if (!mapRef.current) return;
+    if (!L || !mapRef.current) return;
 
     // Remove old markers
     markersRef.current.forEach((marker, id) => {
-      if (!locations.find((loc) => loc.id === id)) {
+      if (!locations.find(loc => loc.id === id)) {
         marker.remove();
         markersRef.current.delete(id);
       }
     });
 
     // Add/update markers
-    locations.forEach((location) => {
+    locations.forEach(location => {
       const existing = markersRef.current.get(location.id);
-
+      
       if (existing) {
-        existing.setLatLng([location.coordinates.lat, location.coordinates.lng]);
+        existing.setLatLng([
+          location.coordinates.lat,
+          location.coordinates.lng
+        ]);
       } else {
         const marker = L.marker(
           [location.coordinates.lat, location.coordinates.lng],
           { draggable: true }
         ).addTo(mapRef.current!);
 
-        marker.on("click", () => onMarkerClick(location));
-        marker.on("dragstart", onMarkerDragStart);
-        marker.on("dragend", (e) => {
+        marker.on('click', () => onMarkerClick(location));
+        marker.on('dragstart', onMarkerDragStart);
+        marker.on('dragend', (e) => {
           const latlng = e.target.getLatLng();
-          onMarkerDragEnd(location.id, latlng.lat, latlng.lng);
+          onMarkerDragEnd(
+            location.id,
+            latlng.lat,
+            latlng.lng
+          );
         });
 
         markersRef.current.set(location.id, marker);
@@ -115,7 +135,7 @@ function LeafletMap({
         }
       }
     });
-  }, [locations, selectedLocation, onMarkerClick, onMarkerDragStart, onMarkerDragEnd]);
+  }, [L, locations, selectedLocation, onMarkerClick, onMarkerDragStart, onMarkerDragEnd]);
 
   // Pan to selected location
   useEffect(() => {
@@ -128,11 +148,8 @@ function LeafletMap({
   }, [selectedLocation]);
 
   return <div id="map" className="w-full h-full" />;
-}
-
-// Dynamically import the LeafletMap component without SSR
-const DynamicLeafletMap = dynamic(() => Promise.resolve(LeafletMap), { ssr: false });
+};
 
 export function LocationMap(props: LocationMapProps) {
-  return <DynamicLeafletMap {...props} />;
+  return <LeafletMap {...props} />;
 }

--- a/components/articles/sidebar/panels/location/LocationMap.tsx
+++ b/components/articles/sidebar/panels/location/LocationMap.tsx
@@ -5,7 +5,7 @@ import dynamic from "next/dynamic";
 import "leaflet/dist/leaflet.css";
 import type { Location } from "@/lib/types/location";
 
-interface LocationMapComponentProps {
+interface LocationMapProps {
   locations: Location[];
   selectedLocation: Location | null;
   onMarkerClick: (location: Location) => void;
@@ -14,14 +14,14 @@ interface LocationMapComponentProps {
   onMapClick: (lat: number, lng: number) => void;
 }
 
-function LocationMapComponent({
+function LeafletMap({
   locations,
   selectedLocation,
   onMarkerClick,
   onMarkerDragStart,
   onMarkerDragEnd,
-  onMapClick
-}: LocationMapComponentProps) {
+  onMapClick,
+}: LocationMapProps) {
   const mapRef = useRef<L.Map | null>(null);
   const markersRef = useRef<Map<string, L.Marker>>(new Map());
 
@@ -41,21 +41,22 @@ function LocationMapComponent({
       });
 
       const defaultCenter = { lat: 33.8938, lng: 35.5018 }; // Beirut
-      
-      mapRef.current = L.map('map', {
+
+      mapRef.current = L.map("map", {
         center: [defaultCenter.lat, defaultCenter.lng],
         zoom: 13,
         zoomControl: true,
       });
 
       // Add OpenStreetMap tiles
-      L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+      L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+        attribution:
+          '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
         maxZoom: 19,
       }).addTo(mapRef.current);
 
       // Add click listener
-      mapRef.current.on('click', (e) => {
+      mapRef.current.on("click", (e) => {
         onMapClick(e.latlng.lat, e.latlng.lng);
       });
     };
@@ -70,155 +71,68 @@ function LocationMapComponent({
     };
   }, [onMapClick]);
 
-  // Rest of the component implementation...
+  // Update markers
+  useEffect(() => {
+    if (!mapRef.current) return;
+
+    // Remove old markers
+    markersRef.current.forEach((marker, id) => {
+      if (!locations.find((loc) => loc.id === id)) {
+        marker.remove();
+        markersRef.current.delete(id);
+      }
+    });
+
+    // Add/update markers
+    locations.forEach((location) => {
+      const existing = markersRef.current.get(location.id);
+
+      if (existing) {
+        existing.setLatLng([location.coordinates.lat, location.coordinates.lng]);
+      } else {
+        const marker = L.marker(
+          [location.coordinates.lat, location.coordinates.lng],
+          { draggable: true }
+        ).addTo(mapRef.current!);
+
+        marker.on("click", () => onMarkerClick(location));
+        marker.on("dragstart", onMarkerDragStart);
+        marker.on("dragend", (e) => {
+          const latlng = e.target.getLatLng();
+          onMarkerDragEnd(location.id, latlng.lat, latlng.lng);
+        });
+
+        markersRef.current.set(location.id, marker);
+      }
+
+      // Update marker style if selected
+      const marker = markersRef.current.get(location.id);
+      if (marker) {
+        if (selectedLocation?.id === location.id) {
+          marker.setZIndexOffset(1000); // Bring to front
+        } else {
+          marker.setZIndexOffset(0);
+        }
+      }
+    });
+  }, [locations, selectedLocation, onMarkerClick, onMarkerDragStart, onMarkerDragEnd]);
+
+  // Pan to selected location
+  useEffect(() => {
+    if (!mapRef.current || !selectedLocation) return;
+
+    mapRef.current.setView(
+      [selectedLocation.coordinates.lat, selectedLocation.coordinates.lng],
+      mapRef.current.getZoom()
+    );
+  }, [selectedLocation]);
+
   return <div id="map" className="w-full h-full" />;
 }
 
-// Dynamically import the map component with no SSR
-const LocationMap = dynamic(
-  () => Promise.resolve(LocationMapComponent),
-  { ssr: false }
-);
-
-interface LocationMapProps {
-  locations: Location[];
-  selectedLocation: Location | null;
-  onMarkerClick: (location: Location) => void;
-  onMarkerDragStart: () => void;
-  onMarkerDragEnd: (locationId: string, lat: number, lng: number) => void;
-  onMapClick: (lat: number, lng: number) => void;
-}
-
-export function LocationMapWrapper(props: LocationMapProps) {
-  return <LocationMap {...props} />;
-}
-      locations, 
-      selectedLocation, 
-      onMarkerClick, 
-      onMarkerDragStart, 
-      onMarkerDragEnd, 
-      onMapClick 
-    }: LocationMapProps) => {
-      const mapRef = useRef<L.Map | null>(null);
-      const markersRef = useRef<Map<string, L.Marker>>(new Map());
-
-      // Initialize map
-      useEffect(() => {
-        if (mapRef.current) return;
-
-        // Fix Leaflet icon path issue
-        delete (L.Icon.Default.prototype as any)._getIconUrl;
-        L.Icon.Default.mergeOptions({
-          iconRetinaUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon-2x.png',
-          iconUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon.png',
-          shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-shadow.png',
-        });
-
-        const defaultCenter = { lat: 33.8938, lng: 35.5018 }; // Beirut
-        
-        mapRef.current = L.map('map', {
-          center: [defaultCenter.lat, defaultCenter.lng],
-          zoom: 13,
-          zoomControl: true,
-        });
-
-        // Add OpenStreetMap tiles
-        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-          attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-          maxZoom: 19,
-        }).addTo(mapRef.current);
-
-        // Add click listener
-        mapRef.current.on('click', (e) => {
-          onMapClick(e.latlng.lat, e.latlng.lng);
-        });
-
-        return () => {
-          if (mapRef.current) {
-            mapRef.current.remove();
-            mapRef.current = null;
-          }
-        };
-      }, [onMapClick]);
-
-      // Update markers
-      useEffect(() => {
-        if (!mapRef.current) return;
-
-        // Remove old markers
-        markersRef.current.forEach((marker, id) => {
-          if (!locations.find(loc => loc.id === id)) {
-            marker.remove();
-            markersRef.current.delete(id);
-          }
-        });
-
-        // Add/update markers
-        locations.forEach(location => {
-          const existing = markersRef.current.get(location.id);
-          
-          if (existing) {
-            existing.setLatLng([
-              location.coordinates.lat,
-              location.coordinates.lng
-            ]);
-          } else {
-            const marker = L.marker(
-              [location.coordinates.lat, location.coordinates.lng],
-              { draggable: true }
-            ).addTo(mapRef.current!);
-
-            marker.on('click', () => onMarkerClick(location));
-            marker.on('dragstart', onMarkerDragStart);
-            marker.on('dragend', (e) => {
-              const latlng = e.target.getLatLng();
-              onMarkerDragEnd(
-                location.id,
-                latlng.lat,
-                latlng.lng
-              );
-            });
-
-            markersRef.current.set(location.id, marker);
-          }
-
-          // Update marker style if selected
-          const marker = markersRef.current.get(location.id);
-          if (marker) {
-            if (selectedLocation?.id === location.id) {
-              marker.setZIndexOffset(1000); // Bring to front
-            } else {
-              marker.setZIndexOffset(0);
-            }
-          }
-        });
-      }, [locations, selectedLocation, onMarkerClick, onMarkerDragStart, onMarkerDragEnd]);
-
-      // Pan to selected location
-      useEffect(() => {
-        if (!mapRef.current || !selectedLocation) return;
-
-        mapRef.current.setView(
-          [selectedLocation.coordinates.lat, selectedLocation.coordinates.lng],
-          mapRef.current.getZoom()
-        );
-      }, [selectedLocation]);
-
-      return <div id="map" className="w-full h-full" />;
-    };
-  },
-  { ssr: false }
-);
-
-interface LocationMapProps {
-  locations: Location[];
-  selectedLocation: Location | null;
-  onMarkerClick: (location: Location) => void;
-  onMarkerDragStart: () => void;
-  onMarkerDragEnd: (locationId: string, lat: number, lng: number) => void;
-  onMapClick: (lat: number, lng: number) => void;
-}
+// Dynamically import the LeafletMap component without SSR
+const DynamicLeafletMap = dynamic(() => Promise.resolve(LeafletMap), { ssr: false });
 
 export function LocationMap(props: LocationMapProps) {
-  return <LeafletMap {...props} />;
+  return <DynamicLeafletMap {...props} />;
 }

--- a/components/articles/sidebar/panels/location/LocationMapPanel.tsx
+++ b/components/articles/sidebar/panels/location/LocationMapPanel.tsx
@@ -8,6 +8,7 @@ import { LocationSearch } from "./LocationSearch";
 import { LocationList } from "./LocationList";
 import { cn } from "@/lib/utils/styles";
 import type { Location } from "@/lib/types/location";
+import { LocationMap } from "./LocationMap";
 
 export function LocationMapPanel() {
   const [locations, setLocations] = useState<Location[]>([]);
@@ -34,6 +35,16 @@ export function LocationMapPanel() {
     ));
   };
 
+  const handleMapClick = (lat: number, lng: number) => {
+    const newLocation: Location = {
+      id: crypto.randomUUID(),
+      name: `Location at ${lat.toFixed(6)}, ${lng.toFixed(6)}`,
+      address: "Custom location",
+      coordinates: { lat, lng },
+    };
+    handleAddLocation(newLocation);
+  };
+
   return (
     <div className="h-[calc(100vh-84px)] flex">
       {/* Left panel */}
@@ -49,7 +60,7 @@ export function LocationMapPanel() {
 
       {/* Map */}
       <div className="flex-1 relative">
-        <Card className="absolute inset-0 m-4 overflow-hidden">
+        {/* <Card className="absolute inset-0 m-4 overflow-hidden">
           <div className="relative h-full bg-gray-100">
             <div className="absolute inset-0 flex items-center justify-center">
               <p className="text-gray-500">
@@ -68,7 +79,15 @@ export function LocationMapPanel() {
               })}
             />
           </div>
-        </Card>
+        </Card> */}
+        <LocationMap
+          locations={locations}
+          selectedLocation={selectedLocation}
+          onMarkerClick={setSelectedLocation}
+          onMarkerDragStart={() => {}}
+          onMarkerDragEnd={handleMarkerDragEnd}
+          onMapClick={handleMapClick}
+        />
       </div>
     </div>
   );

--- a/components/articles/sidebar/panels/location/LocationMapPanel.tsx
+++ b/components/articles/sidebar/panels/location/LocationMapPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Search } from "lucide-react";
@@ -15,27 +15,27 @@ export function LocationMapPanel() {
   const [selectedLocation, setSelectedLocation] = useState<Location | null>(null);
   const [isDragging, setIsDragging] = useState(false);
 
-  const handleAddLocation = (location: Location) => {
+  const handleAddLocation = useCallback((location: Location) => {
     setLocations(prev => [...prev, location]);
     setSelectedLocation(location);
-  };
+  }, {});
 
-  const handleRemoveLocation = (locationId: string) => {
+  const handleRemoveLocation = useCallback((locationId: string) => {
     setLocations(prev => prev.filter(loc => loc.id !== locationId));
     if (selectedLocation?.id === locationId) {
       setSelectedLocation(null);
     }
-  };
+  }, [selectedLocation]);
 
-  const handleMarkerDragEnd = (locationId: string, lat: number, lng: number) => {
+  const handleMarkerDragEnd = useCallback((locationId: string, lat: number, lng: number) => {
     setLocations(prev => prev.map(loc => 
       loc.id === locationId 
         ? { ...loc, coordinates: { lat, lng } }
         : loc
     ));
-  };
+  }, []);
 
-  const handleMapClick = (lat: number, lng: number) => {
+  const handleMapClick = useCallback((lat: number, lng: number) => {
     const newLocation: Location = {
       id: crypto.randomUUID(),
       name: `Location at ${lat.toFixed(6)}, ${lng.toFixed(6)}`,
@@ -43,7 +43,7 @@ export function LocationMapPanel() {
       coordinates: { lat, lng },
     };
     handleAddLocation(newLocation);
-  };
+  }, [handleAddLocation]);
 
   return (
     <div className="h-[calc(100vh-84px)] flex">
@@ -60,26 +60,6 @@ export function LocationMapPanel() {
 
       {/* Map */}
       <div className="flex-1 relative">
-        {/* <Card className="absolute inset-0 m-4 overflow-hidden">
-          <div className="relative h-full bg-gray-100">
-            <div className="absolute inset-0 flex items-center justify-center">
-              <p className="text-gray-500">
-                Map functionality temporarily disabled.
-                <br />
-                Click to add a location:
-              </p>
-            </div>
-            <div 
-              className="absolute inset-0 cursor-pointer"
-              onClick={() => handleAddLocation({
-                id: crypto.randomUUID(),
-                name: `Location at ${lat.toFixed(6)}, ${lng.toFixed(6)}`,
-                address: "Custom location",
-                coordinates: { lat, lng }
-              })}
-            />
-          </div>
-        </Card> */}
         <LocationMap
           locations={locations}
           selectedLocation={selectedLocation}

--- a/components/news/content/NewsContentInput.tsx
+++ b/components/news/content/NewsContentInput.tsx
@@ -2,7 +2,6 @@
 
 import { Textarea } from "@/components/ui/textarea";
 import { EmojiPicker } from "./emoji";
-import { EmojiPicker } from "./emoji/EmojiPicker";
 import { cn } from "@/lib/utils";
 
 interface NewsContentInputProps {
@@ -20,10 +19,6 @@ export function NewsContentInput({
   className,
   direction = "ltr"
 }: NewsContentInputProps) {
-  const handleEmojiSelect = (emoji: string) => {
-    onChange(value + emoji);
-  };
-
   const handleEmojiSelect = (emoji: string) => {
     onChange(value + emoji);
   };

--- a/package.json
+++ b/package.json
@@ -9,13 +9,10 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@emoji-mart/data": "^1.1.2",
+    "@emoji-mart/react": "^1.1.1",
     "@radix-ui/react-alert-dialog": "^1.0.5",
     "@radix-ui/react-avatar": "^1.0.4",
-    "@emoji-mart/data": "^1.1.2",
-    "@emoji-mart/react": "^1.1.1",
-    "@emoji-mart/data": "^1.1.2",
-    "@emoji-mart/react": "^1.1.1",
-    "react-day-picker": "^8.10.0",
     "@radix-ui/react-checkbox": "^1.0.4",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-dropdown-menu": "^2.0.6",


### PR DESCRIPTION
Check that emoji selectors are working (there should be one in the live updates main entry field and then in teh article editor (the floating toolbar) - [DONE]

Fix the scheduling of the article editor - [DONE]

In the article editor, have the text format toolbar floating outside the story area on the left of it not inside it - [DONE]

In the featured image panel of the article editor: It should be working this way but it's not:
For the featured image generator, the vertical preview, when in dual mode, should show the 2 uploads stacked on top of each other with a white separator between them. There's also a selection of "dual" "single"for the vertical preview in dual mode. Dual is default and will show the switch icon to switch between top and bottom positions. If Single, the switch icon will switch between the 2 uploads. - [WORKING ON]

In the Location panel of the article editor: Leaflet doesn't seem to be working for the map. Here it shows the map in the full panel and a search option. Then the ability to add marker(s) on the map - [DONE]

In the translation panel of the article: It's showing the headline/story editor from the content panel. Please remove it (as well as removing it from the location panel) - [DONE]